### PR TITLE
Remove ```max_llm_calls_per_minute``` option

### DIFF
--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Foobara::Agent do
       verbose:,
       io_out:,
       io_err:,
-      include_message_to_user_in_result:,
-      max_llm_calls_per_minute:
+      include_message_to_user_in_result:
     }
 
     if result_entity_depth
@@ -42,7 +41,6 @@ RSpec.describe Foobara::Agent do
   let(:verbose) { false }
   let(:io_out) { nil }
   let(:io_err) { nil }
-  let(:max_llm_calls_per_minute) { nil }
   let(:result_entity_depth) { nil }
   let(:pass_aggregates_to_llm) { nil }
 
@@ -211,25 +209,6 @@ RSpec.describe Foobara::Agent do
               Capybaras::Capybara.find_by(name: "Barbara").year_of_birth
             end
           }.from(2019).to(19)
-        end
-
-        context "when throttling calls per minute" do
-          let(:max_llm_calls_per_minute) { 2 }
-
-          before do
-            stub_const("Foobara::Agent::AccomplishGoal::SECONDS_PER_MINUTE", 1)
-          end
-
-          it "can fix the busted record", vcr: { record: :none } do
-            expect {
-              expect(outcome).to be_success
-              expect(result[:result_data].name).to eq("Barbara")
-            }.to change {
-              Capybaras::Capybara.transaction do
-                Capybaras::Capybara.find_by(name: "Barbara").year_of_birth
-              end
-            }.from(19).to(2019)
-          end
         end
       end
 

--- a/src/foobara/agent.rb
+++ b/src/foobara/agent.rb
@@ -24,7 +24,6 @@ module Foobara
                   :verbose,
                   :io_out,
                   :io_err,
-                  :max_llm_calls_per_minute,
                   :pass_aggregates_to_llm,
                   :result_entity_depth
 
@@ -38,7 +37,6 @@ module Foobara
       verbose: false,
       io_out: nil,
       io_err: nil,
-      max_llm_calls_per_minute: nil,
       result_entity_depth: AssociationDepth::AGGREGATE,
       pass_aggregates_to_llm: nil,
       **opts
@@ -55,7 +53,6 @@ module Foobara
       self.verbose = verbose
       self.io_out = io_out
       self.io_err = io_err
-      self.max_llm_calls_per_minute = max_llm_calls_per_minute
       self.result_entity_depth = result_entity_depth
       self.pass_aggregates_to_llm = pass_aggregates_to_llm
 
@@ -218,10 +215,6 @@ module Foobara
 
       if include_message_to_user_in_result || include_message_to_user_in_result == false
         inputs[:include_message_to_user_in_result] = include_message_to_user_in_result
-      end
-
-      if max_llm_calls_per_minute && max_llm_calls_per_minute > 0
-        inputs[:max_llm_calls_per_minute] = max_llm_calls_per_minute
       end
 
       if result_entity_depth

--- a/src/foobara/agent/accomplish_goal.rb
+++ b/src/foobara/agent/accomplish_goal.rb
@@ -28,7 +28,6 @@ module Foobara
                   one_of: Ai::AnswerBot::Types::ModelEnum,
                   default: Ai.default_llm_model,
                   description: "The model to use for the LLM"
-        max_llm_calls_per_minute :integer, :allow_nil
         user_association_depth :symbol, :allow_nil, one_of: Foobara::AssociationDepth
         result_entity_depth :symbol, :allow_nil, one_of: Foobara::AssociationDepth
         pass_aggregates_to_llm :boolean, :allow_nil
@@ -51,8 +50,6 @@ module Foobara
         until mission_accomplished or given_up or killed
           increment_command_calls
           check_if_too_many_calls
-
-          throttle_llm_calls_if_necessary
 
           determine_next_command_and_inputs
 
@@ -520,19 +517,6 @@ module Foobara
           # :nocov:
           0
           # :nocov:
-        end
-      end
-
-      def throttle_llm_calls_if_necessary
-        return unless max_llm_calls_per_minute && max_llm_calls_per_minute > 0
-
-        if llm_call_count_in_last_minute >= max_llm_calls_per_minute
-          seconds = time_until_llm_call_count_in_last_minute_changes
-          if verbose?
-            (io_out || $stdout).puts "Sleeping for #{seconds} seconds to avoid LLM calls per minute limit"
-          end
-
-          sleep seconds
         end
       end
 

--- a/src/foobara/agent/accomplish_goal.rb
+++ b/src/foobara/agent/accomplish_goal.rb
@@ -3,9 +3,6 @@ require_relative "list_commands"
 module Foobara
   class Agent < CommandConnector
     class AccomplishGoal < Foobara::Command
-      # Using a const here so we can stub it in the test suite to speed things up
-      SECONDS_PER_MINUTE = 60
-
       possible_error :gave_up, context: { reason: :string }, message: "Gave up."
       possible_error :too_many_command_calls,
                      context: { maximum_command_calls: :integer }

--- a/src/foobara/agent/accomplish_goal.rb
+++ b/src/foobara/agent/accomplish_goal.rb
@@ -497,29 +497,6 @@ module Foobara
         llm_call_timestamps.unshift(Time.now)
       end
 
-      def llm_calls_in_last_minute
-        llm_call_timestamps.select { |t| t > (Time.now - 60) }
-      end
-
-      def llm_call_count_in_last_minute
-        llm_calls_in_last_minute.size
-      end
-
-      def time_until_llm_call_count_in_last_minute_changes
-        calls = llm_calls_in_last_minute
-
-        first_to_expire = calls.first
-
-        if first_to_expire
-          [0, (first_to_expire + SECONDS_PER_MINUTE) - Time.now].max
-        else
-          # TODO: figure out how to test this code path
-          # :nocov:
-          0
-          # :nocov:
-        end
-      end
-
       def context
         agent.context
       end


### PR DESCRIPTION
This is part of a dual PR which removes the ```max_llm_calls_per_minute``` option from the code base. 